### PR TITLE
Fixed deprecation warning about always_run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
    register: _ssh_config
    ignore_errors: True
    changed_when: "_ssh_config.rc == 1"
-   always_run: yes
+   check_mode: no
    tags: [configuration,ssh]
 
  - name: ensure header for config exist


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead
This feature will be removed in version 2.4.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>